### PR TITLE
chore: chatgpt-4o-latest -> gpt-4o

### DIFF
--- a/mizuki_bot/cogs/ai.py
+++ b/mizuki_bot/cogs/ai.py
@@ -10,7 +10,7 @@ import io
 import asyncio
 from .. import ai, db
 
-AIModel = "chatgpt-4o-latest"
+AIModel = "gpt-4o"
 
 class DrawModel(IntEnum):
     Prefect_Pony_XL_v5 = 1


### PR DESCRIPTION
OpenAI removed chatgpt-4o-latest in Feb 17th
Update to use `gpt-4o` instead of `chatgpt-4o-latest`


<img width="1796" height="474" alt="image" src="https://github.com/user-attachments/assets/960387d8-992d-4d1c-ae0d-18a3237352f5" />

